### PR TITLE
Fix the fuel loop status in logger

### DIFF
--- a/Logger/Parameters.Standard.xml
+++ b/Logger/Parameters.Standard.xml
@@ -358,7 +358,7 @@
         storageType="uint8"
         bitMapped="True"
         bitIndex="0">
-        <Conversion units="Boolean" expression="Open,Closed" format="0" />
+        <Conversion units="Boolean" expression="Closed,Open" format="0" />
     </Parameter>
     <Parameter
         id="1105"


### PR DESCRIPTION
The fuel loop status in Logger is currently backwards. When the car is in open loop, it logs it as closed loop and vice versa. This has been test on a P01 PCM