### PR TITLE
ExtraTableName/TableName swap

### DIFF
--- a/Source/PatcherFunctions.cs
+++ b/Source/PatcherFunctions.cs
@@ -2846,6 +2846,17 @@ public class Upatcher
             //Found exact match
             return xTd;
         }
+
+        if(AppSettings.ShowExtraTableName)
+        {
+            xTd = tdList.Where(X => X.ExtraTableName != null && X.ExtraTableName.ToLower() == refTd.TableName.ToLower()).FirstOrDefault();
+            if (xTd != null)
+            {
+                //Found exact match
+                return xTd;
+            }
+        }
+
         int pos1 = refTd.TableName.IndexOf("*");
         if (pos1 < 0)
             pos1 = refTd.TableName.Length;

--- a/Source/TableData.cs
+++ b/Source/TableData.cs
@@ -382,6 +382,11 @@ namespace UniversalPatcher
             ExtraDescription = tSeek.ExtraDescription;
             ExtraTableName = tSeek.ExtraTableName;
 
+            if (AppSettings.ShowExtraTableName && tSeek.ExtraTableName != null)
+            {
+                TableName = tSeek.ExtraTableName;
+                ExtraTableName = ft.Name;
+            }            
             //if (!PCM.tableCategories.Contains(Category))
               //  PCM.tableCategories.Add(Category);
         }

--- a/Source/UpatcherSettings.cs
+++ b/Source/UpatcherSettings.cs
@@ -85,6 +85,7 @@ namespace UniversalPatcher
             LastJScriptFile = "";
             DashboardRows = 2;
             DashboardCols = 3;
+            ShowExtraTableName = false;
 
             TimeoutLoggingActive = TimeoutScenario.DataLogging3;
             TimeoutLoggingActiveObdlink = TimeoutScenario.Minimum;
@@ -299,7 +300,7 @@ namespace UniversalPatcher
         public string LastJScriptFile { get; set; }
         public int DashboardRows { get; set; }
         public int DashboardCols { get; set; }
-
+        public bool ShowExtraTableName { get; set; }
         public Size DashboardWindowSize { get; set; }
         public FormWindowState DashboardWindowState { get; set; }
         public Point DashboardWindowLocation { get; set; }


### PR DESCRIPTION
Added in a setting and supporting code to be able to swap the TableName with ExtraTableName out of the tableseek file.
The ExtraTableName has much more human readable names and aligns more closely with other tuning solutions such as tunerpro

Tested with P01 bins. Saved, compared, opened. Also Saved, compared, opened on 22.30 before I made the changes

![BeforeChanges](https://github.com/user-attachments/assets/1d78f1ba-7065-490d-b032-21bc880958ae)
![AfterChanges](https://github.com/user-attachments/assets/7d4eefcf-5d2c-4b26-8c28-d5699f25a0d8)

