### PR TITLE
Add tunerpro compatible major stride and minor stride support

### DIFF
--- a/Source/DataLogger/Devices/Elm327Device.cs
+++ b/Source/DataLogger/Devices/Elm327Device.cs
@@ -82,10 +82,10 @@ namespace UniversalPatcher
                 this.Port.OpenAsync(configuration);
                 this.Port.DiscardBuffers();
 
-                string response;
                 // This is common across all ELM-based devices.
                 this.SendRequest(""); // send a cr/lf to prevent the ATZ failing.
-                Debug.WriteLine(response = this.SendRequest("AT Z").Data);  // reset
+                string response = this.SendRequest("AT Z").Data;  // reset
+                Debug.WriteLine(response);
                 if (string.IsNullOrWhiteSpace(response))
                 {
                     LoggerBold($"No device found on {this.Port.ToString()}");

--- a/Source/DataLogger/Devices/ElmDeviceImplementation.cs
+++ b/Source/DataLogger/Devices/ElmDeviceImplementation.cs
@@ -73,10 +73,10 @@ namespace UniversalPatcher
         /// </summary>
         public virtual bool Initialize()
         {
-            string response;
             // This is common across all ELM-based devices.
             this.SendRequest(""); // send a cr/lf to prevent the ATZ failing.
-            Debug.WriteLine(response = this.SendRequest("AT Z").Data);  // reset
+            string response = this.SendRequest("AT Z").Data;  // reset
+            Debug.WriteLine(response);
             if(string.IsNullOrWhiteSpace(response))
             {
                 LoggerBold($"No device found on {this.Port.ToString()}");

--- a/Source/DataLogger/Devices/UPX-OBD.cs
+++ b/Source/DataLogger/Devices/UPX-OBD.cs
@@ -1,0 +1,22 @@
+using J2534DotNet;
+
+// Antus: Just a stub to satisfy build dependencies.
+// @joukoy feel free to remove or replace this file.
+
+namespace UniversalPatcher
+{
+    public class UPX_OBD : Elm327Device
+    {
+        public new const string DeviceType = "UPX-OBD";
+
+        public UPX_OBD(IPort port) : base(port)
+        {
+            this.LogDeviceType = DataLogger.LoggingDevType.UPX_OBD;
+        }
+
+        public override string GetDeviceType()
+        {
+            return DeviceType;
+        }
+    }
+}

--- a/Source/PatcherFunctions.cs
+++ b/Source/PatcherFunctions.cs
@@ -1324,12 +1324,16 @@ public class Upatcher
             uint addr = mathTd.StartAddress();
             UInt32 bufAddr = (UInt32)(addr - offset);
             uint elemSize = (uint)mathTd.ElementSize();
+            uint elemStride = (uint)mathTd.EffectiveElementStride((int)elemSize);
             byte byteMask = 0x80;
             if (mathTd.RowMajor)
             {
+                int rowStride = mathTd.EffectiveRowStride((int)elemStride);
                 for (int r = 0; r < mathTd.Rows; r++)
                 {
                     if (r > row) break;
+                    UInt32 rowBufStart = bufAddr;
+                    bool reachedTarget = false;
                     for (int c = 0; c < mathTd.Columns; c++)
                     {
                         if (mathTd.OutputType == OutDataType.Bitmap)
@@ -1347,10 +1351,12 @@ public class Upatcher
                         }
                         else
                         {
-                            bufAddr += elemSize;
+                            bufAddr += elemStride;
                         }
-                        if (r == row && c == column) break;
+                        if (r == row && c == column) { reachedTarget = true; break; }
                     }
+                    if (!reachedTarget && mathTd.OutputType != OutDataType.Bitmap)
+                        bufAddr = rowBufStart + (UInt32)rowStride;
                 }
             }
             else
@@ -1375,7 +1381,7 @@ public class Upatcher
                         }
                         else
                         {
-                            bufAddr += elemSize;
+                            bufAddr += elemStride;
                         }
                         if (r == row && c == column) break;
                     }
@@ -2089,16 +2095,20 @@ public class Upatcher
         List<double> tableValues = new List<double>();
         uint addr = td1.StartAddress();
         uint step = (uint)GetElementSize(td1.DataType);
+        uint es1 = (uint)td1.EffectiveElementStride((int)step);
         if (td1.RowMajor)
         {
+            int rowStride1 = td1.EffectiveRowStride((int)es1);
             for (int r = 0; r < td1.Rows; r++)
             {
+                uint rowStart = addr;
                 for (int c = 0; c < td1.Columns; c++)
                 {
                     double val = GetValue(pcm1.buf,addr,td1,0,pcm1);
                     tableValues.Add(val);
-                    addr += step;
+                    addr += es1;
                 }
+                addr = rowStart + (uint)rowStride1;
             }
         }
         else
@@ -2109,18 +2119,21 @@ public class Upatcher
                 {
                     double val = GetValue(pcm1.buf, addr, td1, 0, pcm1);
                     tableValues.Add(val);
-                    addr += step;
+                    addr += es1;
                 }
             }
         }
 
         addr = td2.StartAddress();
         step = (uint)GetElementSize(td2.DataType);
+        uint es2 = (uint)td2.EffectiveElementStride((int)step);
         int i = 0;
         if (td2.RowMajor)
         {
+            int rowStride2 = td2.EffectiveRowStride((int)es2);
             for (int r = 0; r < td2.Rows; r++)
             {
+                uint rowStart = addr;
                 for (int c = 0; c < td2.Columns; c++)
                 {
                     double val = GetValue(pcm2.buf, addr, td2, 0,pcm2);
@@ -2129,9 +2142,10 @@ public class Upatcher
                         match = false;
                         break;
                     }
-                    addr += step;
+                    addr += es2;
                     i++;
                 }
+                addr = rowStart + (uint)rowStride2;
             }
         }
         else
@@ -2146,7 +2160,7 @@ public class Upatcher
                         match = false;
                         break;
                     }
-                    addr += step;
+                    addr += es2;
                     i++;
                 }
             }

--- a/Source/TableData.cs
+++ b/Source/TableData.cs
@@ -159,6 +159,8 @@ namespace UniversalPatcher
         //public bool Floating;
         public ushort Columns { get; set; }
         public ushort Rows { get; set; }
+        public ushort RowStride { get; set; }
+        public ushort ElementStride { get; set; }
         public Byte_Order ByteOrder { get; set; }
         public string BitMask { get; set; }
         public bool RowMajor { get; set; }
@@ -285,6 +287,21 @@ namespace UniversalPatcher
         public uint EndAddressNoExtra()
         {
             return (uint)(addrInt + Offset + Size());
+        }
+
+        // Returns the per-element step in bytes (TunerPro major stride).
+        // Falls back to elemSize when ElementStride is not set.
+        public int EffectiveElementStride(int elemSize)
+        {
+            return ElementStride > 0 ? ElementStride : elemSize;
+        }
+
+        // Returns the byte distance from row start to next row start (TunerPro minor stride).
+        // Pass the effective element stride, not the raw element size.
+        // Falls back to Columns * elemStride when RowStride is not set.
+        public int EffectiveRowStride(int elemStride)
+        {
+            return RowStride > 0 ? RowStride : Columns * elemStride;
         }
 
         public int Size()

--- a/Source/TableData.cs
+++ b/Source/TableData.cs
@@ -171,6 +171,7 @@ namespace UniversalPatcher
         public string ExtraCategories { get; set; }
         public string TableDescription { get; set; }
         public string ExtraDescription { get; set; }
+        public bool HideFromTree { get; set; }
         public string OS_Address { get; set; }
 
         private string altOS;

--- a/Source/TreeParts.cs
+++ b/Source/TreeParts.cs
@@ -645,6 +645,8 @@ namespace UniversalPatcher
 
                 for (int i = 0; i < filteredTableDatas.Count; i++)
                 {
+                    if (filteredTableDatas[i].HideFromTree)
+                        continue;
                     //string cat = filteredTableDatas[i].Category;
                     string cat = "";
                     string[] mainCats = filteredTableDatas[i].MainCategories().ToArray();
@@ -736,7 +738,8 @@ namespace UniversalPatcher
                             }
                         }
                     }
-                    if (tnC2.Node.Nodes.Count > 0)
+                    bool hasExtraCats = TableDatas.Any(td => !string.IsNullOrEmpty(td.ExtraCategories));
+                    if (hasExtraCats && tnC2.Node.Nodes.Count > 0)
                     {
                         parent.Add(tnC2.Node);
                     }

--- a/Source/UniversalPatcher.csproj
+++ b/Source/UniversalPatcher.csproj
@@ -49,6 +49,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/Source/frmHexDiff.cs
+++ b/Source/frmHexDiff.cs
@@ -533,16 +533,20 @@ namespace UniversalPatcher
                     frmTE.PrepareTable(pcm1, pTd, null, "A");
                     frmTE.LoadTable();
                     uint step = (uint)GetElementSize(pTd.DataType);
+                    uint elemStride = (uint)pTd.EffectiveElementStride((int)step);
                     uint addr = pTd.StartAddress();
                     if (pTd.RowMajor)
                     {
+                        int rowStride = pTd.EffectiveRowStride((int)elemStride);
                         for (int r = 0; r < pTd.Rows; r++)
                         {
+                            uint rowStart = addr;
                             for (int c = 0; c < pTd.Columns; c++)
                             {
                                 xpatch.Data += GetValue(pcm1.buf, addr, pTd, 0, pcm1).ToString().Replace(",", ".") + " ";
-                                addr += step;
+                                addr += elemStride;
                             }
+                            addr = rowStart + (uint)rowStride;
                         }
                     }
                     else
@@ -552,7 +556,7 @@ namespace UniversalPatcher
                             for (int r = 0; r < pTd.Rows; r++)
                             {
                                 xpatch.Data += GetValue(pcm1.buf, addr, pTd, 0, pcm1).ToString().Replace(",", ".") + " ";
-                                addr += step;
+                                addr += elemStride;
                             }
                         }
                     }

--- a/Source/frmMassCompare.cs
+++ b/Source/frmMassCompare.cs
@@ -175,17 +175,22 @@ namespace UniversalPatcher
                 {
                     string tblData = ""; //"Current values: " + Environment.NewLine;
                     uint addr = compTd.StartAddress();
+                    uint elemStep = (uint)GetElementSize(compTd.DataType);
+                    uint elemStride = (uint)compTd.EffectiveElementStride((int)elemStep);
                     if (compTd.RowMajor)
                     {
+                        int rowStride = compTd.EffectiveRowStride((int)elemStride);
                         for (int r = 0; r < compTd.Rows; r++)
                         {
+                            uint rowStart = addr;
                             for (int c = 0; c < compTd.Columns; c++)
                             {
                                 double curVal = GetValue(peekPCM.buf, addr, compTd,0, peekPCM);
-                                addr += (uint)GetElementSize(compTd.DataType);
+                                addr += elemStride;
                                 tblData += "[" + curVal.ToString("#0.0") + "]";
                             }
                             tblData += Environment.NewLine;
+                            addr = rowStart + (uint)rowStride;
                         }
                     }
                     else
@@ -199,7 +204,7 @@ namespace UniversalPatcher
                             for (int r = 0; r < compTd.Rows; r++)
                             {
                                 double curVal = GetValue(peekPCM.buf, addr, compTd,0, peekPCM);
-                                addr += (uint)GetElementSize(compTd.DataType);
+                                addr += elemStride;
                                 tblRows[r] += "[" + curVal.ToString("#0.0") + "]";
                             }
                         }

--- a/Source/frmTableEditor.cs
+++ b/Source/frmTableEditor.cs
@@ -721,12 +721,15 @@ namespace UniversalPatcher
                     }
                     uint addr = tData.StartAddress();
                     int step = GetElementSize(tData.DataType);
+                    int elemStride = tData.EffectiveElementStride(step);
                     byte mask = 1;
-                    
+
                     if (tData.RowMajor)
                     {
+                        int rowStride = tData.EffectiveRowStride(elemStride);
                         for (int r = 0; r < tData.Rows; r++)
                         {
+                            uint rowStart = addr;
                             for (int c = 0; c < tData.Columns; c++)
                             {
                                 TableCell tc = new TableCell(tData,tInfo,addr,c,r,rowHeaders[r], colHeaders[c]);
@@ -753,10 +756,12 @@ namespace UniversalPatcher
                                     tc.lastValue = GetValue(pcm.buf, addr, tData, 0, pcm);
                                     tc.lastRawValue = GetRawValue(pcm.buf, addr, tData, 0, pcm.platformConfig.MSB);
                                     Array.Copy(pcm.buf,addr, tc.lastRawBytes, 0, step);
-                                    addr += (uint)step;
+                                    addr += (uint)elemStride;
                                 }
                                 tInfo.tableCells.Add(tc);
                             }
+                            if (tData.OutputType != OutDataType.Bitmap)
+                                addr = rowStart + (uint)rowStride;
                         }
                     }
                     else
@@ -790,7 +795,7 @@ namespace UniversalPatcher
                                     tc.lastValue = GetValue(pcm.buf, addr, tData, 0, pcm);
                                     tc.lastRawValue = GetRawValue(pcm.buf, addr, tData, 0, pcm.platformConfig.MSB);
                                     Array.Copy(pcm.buf, addr, tc.lastRawBytes, 0, step);
-                                    addr += (uint)step;
+                                    addr += (uint)elemStride;
                                 }
                                 tInfo.tableCells.Add(tc);
                             }

--- a/Source/frmTuner.cs
+++ b/Source/frmTuner.cs
@@ -2154,14 +2154,17 @@ namespace UniversalPatcher
                     uint addr = shTd.StartAddress();
                     double firstVal = GetValue(peekPCM.buf, addr, shTd, 0, peekPCM);
                     uint elemSize = (uint)shTd.ElementSize();
+                    uint elemStride = (uint)shTd.EffectiveElementStride((int)elemSize);
                     if (shTd.RowMajor)
                     {
+                        int rowStride = shTd.EffectiveRowStride((int)elemStride);
                         for (int r = 0; r < shTd.Rows; r++)
                         {
+                            uint rowStart = addr;
                             for (int c = 0; c < shTd.Columns; c++)
                             {
                                 double curVal = GetValue(peekPCM.buf, addr, shTd, 0, peekPCM);
-                                addr += elemSize;
+                                addr += elemStride;
                                 tblData.Append("[" + curVal.ToString("#0.0") + "]");
                                 if (!ShowMinMax)
                                 {
@@ -2173,6 +2176,7 @@ namespace UniversalPatcher
                                 }
                             }
                             tblData.Append(Environment.NewLine);
+                            addr = rowStart + (uint)rowStride;
                         }
                     }
                     else
@@ -2185,7 +2189,7 @@ namespace UniversalPatcher
                             for (int r = 0; r < shTd.Rows; r++)
                             {
                                 double curVal = GetValue(peekPCM.buf, addr, shTd, 0, peekPCM);
-                                addr += elemSize;
+                                addr += elemStride;
                                 tblRows[r] += "[" + curVal.ToString("#0.0") + "]";
                                 if (!ShowMinMax)
                                 {
@@ -3564,16 +3568,20 @@ namespace UniversalPatcher
                     frmTE.PrepareTable(PCM, pTd, null, "A");
                     frmTE.LoadTable();
                     uint step = (uint)GetElementSize(pTd.DataType);
+                    uint elemStride = (uint)pTd.EffectiveElementStride((int)step);
                     uint addr = pTd.StartAddress();
                     if (pTd.RowMajor)
                     {
+                        int rowStride = pTd.EffectiveRowStride((int)elemStride);
                         for (int r = 0; r < pTd.Rows; r++)
                         {
+                            uint rowStart = addr;
                             for (int c = 0; c < pTd.Columns; c++)
                             {
                                 xpatch.Data += GetValue(PCM.buf, addr, pTd, 0, PCM).ToString().Replace(",", ".") + " ";
-                                addr += step;
+                                addr += elemStride;
                             }
+                            addr = rowStart + (uint)rowStride;
                         }
                     }
                     else
@@ -3583,7 +3591,7 @@ namespace UniversalPatcher
                             for (int r = 0; r < pTd.Rows; r++)
                             {
                                 xpatch.Data += GetValue(PCM.buf, addr, pTd, 0, PCM).ToString().Replace(",", ".") + " ";
-                                addr += step;
+                                addr += elemStride;
                             }
                         }
                     }
@@ -3637,17 +3645,21 @@ namespace UniversalPatcher
                     frmTE.PrepareTable(PCM, srcTd, null, "A");
                     frmTE.LoadTable();
                     uint step = (uint)GetElementSize(srcTd.DataType);
+                    uint elemStride = (uint)srcTd.EffectiveElementStride((int)step);
                     uint addr = srcTd.StartAddress();
                     patchTd.Values = "TablePatch: ";
                     if (srcTd.RowMajor)
                     {
+                        int rowStride = srcTd.EffectiveRowStride((int)elemStride);
                         for (int r = 0; r < srcTd.Rows; r++)
                         {
+                            uint rowStart = addr;
                             for (int c = 0; c < srcTd.Columns; c++)
                             {
                                 patchTd.Values += GetValue(PCM.buf, addr, srcTd, 0, PCM).ToString().Replace(",", ".") + " ";
-                                addr += step;
+                                addr += elemStride;
                             }
+                            addr = rowStart + (uint)rowStride;
                         }
                     }
                     else
@@ -3657,7 +3669,7 @@ namespace UniversalPatcher
                             for (int r = 0; r < srcTd.Rows; r++)
                             {
                                 patchTd.Values += GetValue(PCM.buf, addr, srcTd, 0, PCM).ToString().Replace(",", ".") + " ";
-                                addr += step;
+                                addr += elemStride;
                             }
                         }
                     }


### PR DESCRIPTION
## RowStride + ElementStride support (TunerPro major/minor stride parity)

fields per table:

# Tunerpro XDF variables:
| XDF field | Meaning |
|-----------|---------|
| `mmedminorstridebits` | Row alignment boundary — each new row starts at the next multiple of N bits|
| `mmedmajorstridebits` | Element step — 0/natural = packed; 16×elem = skip 1 byte between elements; 24×elem = skip 2 bytes, etc. |

UniversalPatcher had no equivalent, so tables with padding would display
incorrectly - a "diagonal stripe" pattern where padding bytes were read as data.
XML Creators defined an unused column as a workaround. This allows them to hide the padding.

Note: Tunerpro shows bytes in the UI, and saves as bits. So lets make UP compatible with the Tunerpro UI. While an XDF will have mmedminorstridebits = 16 for word alignment, it will show 2 in the UI. This UP code, while based on the same principals, uses bytes. So a value of 2 can be copied directly from the Tunerpro UI to the UP XML. If doing the work programmatically then the value of 16 needs to be divided by 8 and saved as 2 in the XML.

### Changes

**`TableData.cs`**
- `RowStride` (`ushort`) - byte distance row-to-row; 0 = natural
- `ElementStride` (`ushort`) - byte step element-to-element; 0 = natural
- `EffectiveRowStride(int elemStride)` helper (falls back to `Columns × elemStride`)
- `EffectiveElementStride(int elemSize)` helper (falls back to `elemSize`)

**Loop sites updated**
- `frmTableEditor.cs` - display read/write loop (row-major branch)
- `frmTuner.cs` - peek display loop; first and second patch-generation loops
- `PatcherFunctions.cs` - `GetValueByRowColumn()` and `CompareTables()`
- `frmHexDiff.cs` - patch export loop
- `frmMassCompare.cs` - comparison display loop

### Backward compatibility

All existing XML files that omit `<RowStride>` and `<ElementStride>` continue to
work unchanged - the effective stride falls back to the natural packed layout.